### PR TITLE
Avoid PHP 8.1 deprecation notices.

### DIFF
--- a/lib/Document.php
+++ b/lib/Document.php
@@ -31,7 +31,11 @@ class Document extends \DOMDocument implements XPathAware
      */
     public function __construct($version = '1.0', $encoding = null)
     {
-        parent::__construct($version, $encoding);
+        if ($encoding) {
+            parent::__construct($version, $encoding);
+        } else {
+            parent::__construct($version);
+        }
         $this->registerNodeClass('DOMElement', 'PhpBench\Dom\Element');
     }
 

--- a/lib/XPath.php
+++ b/lib/XPath.php
@@ -23,6 +23,7 @@ class XPath extends \DOMXPath
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function evaluate($expression, $contextnode = null, $registerNodeNS = true)
     {
         $result = $this->execute('evaluate', 'expression', $expression, $contextnode, $registerNodeNS);
@@ -33,6 +34,7 @@ class XPath extends \DOMXPath
     /**
      * @return DOMNodeList<DOMNode>
      */
+    #[\ReturnTypeWillChange]
     public function query($expression, $contextnode = null, $registerNodeNS = true)
     {
         return $this->execute('query', 'query', $expression, $contextnode, $registerNodeNS);
@@ -64,6 +66,7 @@ class XPath extends \DOMXPath
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     private function execute(string $method, string $context, string $query, DOMNode $contextEl = null, bool $registerNodeNs = false)
     {
         libxml_use_internal_errors(true);


### PR DESCRIPTION
This avoids all PHP 8.1 deprecation notices in this package, and allows all tests to pass green.  (Tested on 8.1 RC2.)